### PR TITLE
Update inner-join.md (typo on inner join example)

### DIFF
--- a/sql/dql/joins/inner-join.md
+++ b/sql/dql/joins/inner-join.md
@@ -75,7 +75,7 @@ INNER JOIN ability_effect_text ON
 ability.id = ability_effect_text.ability_id;
 ```
 
-The first 2 rows of the result would be:
+The first 3 rows of the result would be:
 
 | name      | effect                                                                              |
 |-----------|-------------------------------------------------------------------------------------|


### PR DESCRIPTION
I just want to suggest an edit I wasnt sure if it's a typo or not.

For the inner join example, it's says first two rows of the inner join, but it is showing three rows. I assumed it's a typo and  I just thought it was confusing at first and wanted to ask about it.